### PR TITLE
Add Maven equivalent of the Gradle get-version utility

### DIFF
--- a/foreach-get-version
+++ b/foreach-get-version
@@ -1,1 +1,1 @@
-git submodule foreach -q gradle-get-version
+git submodule foreach -q get-version

--- a/get-version
+++ b/get-version
@@ -1,0 +1,5 @@
+if [ -f "pom.xml" ]; then
+  maven-get-version
+else
+  gradle-get-version
+fi

--- a/maven-get-version
+++ b/maven-get-version
@@ -1,0 +1,1 @@
+ mvn -q -Dexec.executable="printf" -Dexec.args='${project.groupId}\t${project.artifactId}\t${project.version}\n' exec:exec


### PR DESCRIPTION
Following the work on supporting Gradle in these build utilities, this should allow all foreach-get-version* commands to run on any super-repos using either Maven or Gradle as the primary build systems.

## Testing

### Gradle

The behavior of `omero-build should be unchanged

```
sbesson@ls30630:omero-build (master) $ git clone https://github.com/sbesson/build-infra/ -b maven_commands .build
sbesson@ls30630:omero-build (master) $ export PATH=$PATH:$PWD/.build/
sbesson@ls30630:omero-build (master) $ foreach-get-version
org.openmicroscopy	omero-blitz	5.5.0-m7
org.openmicroscopy	omero-common	5.5.0-m7
org.openmicroscopy	omero-model	5.5.0-m7
org.openmicroscopy	omero-renderer	5.5.0-m7
org.openmicroscopy	omero-romio	5.5.0-m7
org.openmicroscopy	omero-server	5.5.0-m7
sbesson@ls30630:omero-build (master) $ foreach-get-version-as-snapshot
...
```

### Maven

With this change, the `foreach-get-version` commands should now be functional on `bio-formats-build` (with and https://github.com/ome/ome-model/pull/101), 
```
sbesson@ls30630:bio-formats-build (master) $ git clone https://github.com/sbesson/build-infra/ -b maven_commands .build
sbesson@ls30630:bio-formats-build (master) $ export PATH=$PATH:$PWD/.build/
sbesson@ls30630:bio-formats-build (master) $ foreach-get-version-as-property 
versions.bio-formats-documentation=6.1.0-SNAPSHOT
versions.bio-formats-examples=6.1.0-SNAPSHOT
versions.pom-bio-formats=6.1.0-SNAPSHOT
versions.turbojpeg=6.1.0-SNAPSHOT
versions.formats-api=6.1.0-SNAPSHOT
versions.formats-bsd=6.1.0-SNAPSHOT
versions.formats-gpl=6.1.0-SNAPSHOT
versions.bio-formats_plugins=6.1.0-SNAPSHOT
versions.bio-formats-tools=6.1.0-SNAPSHOT
versions.bioformats_package=6.1.0-SNAPSHOT
versions.loci_tools=6.1.0-SNAPSHOT
versions.test-suite=6.1.0-SNAPSHOT
versions.ome-codecs=0.2.4-SNAPSHOT
versions.ome-common=6.0.2-SNAPSHOT
versions.ome-jai=0.1.3-SNAPSHOT
versions.ome-mdbtools=5.3.3-SNAPSHOT
versions.metakit=5.3.3-SNAPSHOT
versions.ome-model=6.0.1-SNAPSHOT
versions.specification=6.0.1-SNAPSHOT
versions.ome-xml=6.0.1-SNAPSHOT
versions.ome-model-doc=6.0.1-SNAPSHOT
versions.ome-poi=5.3.4-SNAPSHOT
versions.ome-stubs=5.3.3-SNAPSHOT
versions.lwf-stubs=5.3.3-SNAPSHOT
versions.mipav-stubs=5.3.3-SNAPSHOT
```
notably the ability to export the set of versions as a property files to start recoupling the BIo-Formats and OMERO builds
