### PR TITLE
Improve the pattern replacement to handle ome: and org.openmicroscopy:

### DIFF
--- a/gradle-get-dependencies
+++ b/gradle-get-dependencies
@@ -1,1 +1,1 @@
-printf "$(grep 'ome:\|org.openmicroscopy:' build.gradle | sed 's/^.*\(org.openmicroscopy.*\)$/\1/' | sed 's/^.*\(ome.*\)$/\1/' | tr -cd '0-9a-zA-Z-.:\n' | tr : '\t')\n"
+printf "$(grep 'ome:\|org.openmicroscopy:' build.gradle | sed 's/^.*\(org.openmicroscopy:.*\)$/\1/' | sed 's/^.*\(ome:.*\)$/\1/' | tr -cd '0-9a-zA-Z-.:\n' | tr : '\t')\n"


### PR DESCRIPTION
Since most OMERO artifacts are called `omero-*` they were matching the `ome*`
regexp. With this commit the output of `gradle-get-dependencies` on any
omero-* component should be fixed