### PR TITLE
single repo

### DIFF
--- a/foreach-set-dependencies
+++ b/foreach-set-dependencies
@@ -7,3 +7,5 @@ fi
 
 foreach-get-version >> $VERSION_LOG
 git submodule foreach -q gradle-set-dependencies $VERSION_LOG
+get-version >> $VERSION_LOG
+gradle-set-dependencies $VERSION_LOG


### PR DESCRIPTION
add option for single repo
This will allow repo like omero-insight and omero-matlab to use the snapshot version of the dependency
This is a simple possible option. Tested using https://github.com/ome/omero-insight/pull/27
cc @joshmoore 