### PR TITLE
get-version script uses [[ ]] bashism.

### DIFF
--- a/gradle-get-version
+++ b/gradle-get-version
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 printf "$(grep -E ^group build.gradle | cut -f2 -d= | tr -cd 'a-zA-Z-.')\t"
 printf "$(grep -E ^rootProject.name settings.gradle | cut -f2 -d= | tr -cd 'a-zA-Z-.')\t"
 printf "$(grep -E ^version build.gradle | cut -f2 -d= | tr -cd '0-9a-zA-Z-.')\n"


### PR DESCRIPTION
Without this I get `[[: not found`.