### PR TITLE
Check for .gitmodules in foreach-set-dependencies

### DIFF
--- a/foreach-set-dependencies
+++ b/foreach-set-dependencies
@@ -5,7 +5,11 @@ if [ -z "VERSION_LOG" ]; then
     trap "{ rm -f $VERSION_LOG; }" EXIT
 fi
 
-foreach-get-version >> $VERSION_LOG
-git submodule foreach -q gradle-set-dependencies $VERSION_LOG
-get-version >> $VERSION_LOG
-gradle-set-dependencies $VERSION_LOG
+if test -e .gitmodules;
+then
+    foreach-get-version >> $VERSION_LOG
+    git submodule foreach -q gradle-set-dependencies $VERSION_LOG
+else
+    get-version >> $VERSION_LOG
+    gradle-set-dependencies $VERSION_LOG
+fi


### PR DESCRIPTION
To not print extra lines like `\tomero-build\t`, check
whether this is a submodule-based repository (omero-build)
or a flat repository (omero-insight).

see: https://github.com/ome/build-infra/pull/11