### PR TITLE
Relax the groupId restriction when updating dependencies

### DIFF
--- a/gradle-set-dependencies
+++ b/gradle-set-dependencies
@@ -6,8 +6,7 @@ do
     do
         for suffix in "" "-test";
         do
-            if [[ "${source[0]}" == "${target[0]}"  && \
-                  "${source[1]}" == "${target[1]}${suffix}" ]];
+            if [[ "${source[1]}" == "${target[1]}${suffix}" ]];
             then
                 if [[ "${source[2]}" != "${target[2]}" ]];
                 then


### PR DESCRIPTION
The primary use case is the IDR OMERO build where `omero-build` needs to consume a version of Bio-Formats from a different `groupId`.

This change should allow the gradle-set-dependencies script to replace dependencies matching the artifactId only. This should only be relaxing a condition and preserve the existing logic for merge-ci and latest-ci unless the dependency tree includes artifacts with the same name but different groups.