### PR TITLE
Use setup.py for python repositories

### DIFF
--- a/foreach-get-version
+++ b/foreach-get-version
@@ -1,5 +1,7 @@
 if [ -f "pom.xml" ]; then
   python $(dirname $0)/maven.py --recursive
-else
+elif [ -f "build.gradle" ]; then
   git submodule foreach -q gradle-get-version
+else
+  git submodule foreach -q python-get-version
 fi

--- a/python-get-version
+++ b/python-get-version
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+printf "org.openmicroscopy\t"
+printf "$(python setup.py --name)\t"
+printf "$(python setup.py --version)\n"


### PR DESCRIPTION
 * --name and --version provide provide the bulk of support
 * No concept of a "groupId" is currently implemented
 * "SNAPSHOTS" are simply called `-SNAPSHOT` and are not meant
   for use outside of devspace