### PR TITLE
Fix missing `$` in `VERSION_LOG` check

### DIFF
--- a/foreach-set-dependencies
+++ b/foreach-set-dependencies
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -z "VERSION_LOG" ]; then
+if [ -z "$VERSION_LOG" ]; then
     VERSION_LOG=`mktemp`
     trap "{ rm -f $VERSION_LOG; }" EXIT
 fi


### PR DESCRIPTION
Pretty sure this was the original intention when this check was added in #8. The script fails without this change and can be seen repeatedly upstream with `omero-build` builds on Travis.